### PR TITLE
First-person camera

### DIFF
--- a/lib/hud/crosshair.dart
+++ b/lib/hud/crosshair.dart
@@ -5,11 +5,13 @@ import 'package:space_nico/space_game_3d.dart';
 
 class Crosshair extends Component with HasGameReference<SpaceGame3D> {
   List<(Offset, Offset)> _lines = [];
+  Offset _center = Offset.zero;
 
   @override
   void onGameResize(Vector2 size) {
     super.onGameResize(size);
     final halfSize = size / 2;
+    _center = halfSize.toOffset();
     _lines = [
       (
         (halfSize - Vector2(0, _radius)).toOffset(),
@@ -28,13 +30,18 @@ class Crosshair extends Component with HasGameReference<SpaceGame3D> {
       return;
     }
 
+    canvas.drawCircle(_center, _radius + 2, _paint1);
     for (final line in _lines) {
-      canvas.drawLine(line.$1, line.$2, _paint);
+      canvas.drawLine(line.$1, line.$2, _paint2);
     }
   }
 
   static const _radius = 10.0;
-  static final _paint = Paint()
+  static final _paint1 = Paint()
+    ..color = const Color(0xFFFFFFFF)
+    ..style = PaintingStyle.stroke
+    ..strokeWidth = 1;
+  static final _paint2 = Paint()
     ..color = const Color(0xFFFFFFFF)
     ..strokeWidth = 2;
 }

--- a/lib/key_event_handler.dart
+++ b/lib/key_event_handler.dart
@@ -11,10 +11,10 @@ mixin KeyEventHandler implements KeyboardHandler {
   @override
   bool onKeyEvent(RawKeyEvent event, Set<Key> keysPressed) {
     _keysDown = keysPressed;
-    return propegateKeyEvent;
+    return propagateKeyEvent;
   }
 
-  bool get propegateKeyEvent => true;
+  bool get propagateKeyEvent => true;
 }
 
 typedef Key = LogicalKeyboardKey;

--- a/lib/keyboard_controlled_camera.dart
+++ b/lib/keyboard_controlled_camera.dart
@@ -1,15 +1,11 @@
-import 'dart:async';
-
 import 'package:flame/components.dart' show HasGameReference;
 import 'package:flame_3d/camera.dart';
 import 'package:flame_3d/game.dart';
-import 'package:flutter/services.dart' show RawKeyEvent;
-import 'package:space_nico/key_event_handler.dart';
-import 'package:space_nico/mouse.dart';
+import 'package:space_nico/components/player.dart';
 import 'package:space_nico/space_game_3d.dart';
 
 class KeyboardControlledCamera extends CameraComponent3D
-    with KeyEventHandler, HasGameReference<SpaceGame3D> {
+    with HasGameReference<SpaceGame3D> {
   KeyboardControlledCamera({
     super.world,
     super.viewport,
@@ -18,9 +14,7 @@ class KeyboardControlledCamera extends CameraComponent3D
     super.hudComponents,
   }) : super(
           projection: CameraProjection.perspective,
-          mode: CameraMode.thirdPerson,
-          position: Vector3(0, 0, 0),
-          target: Vector3(0, 0, 0),
+          mode: CameraMode.free,
           up: Vector3(0, 1, 0),
           fovY: 60,
         );
@@ -30,36 +24,7 @@ class KeyboardControlledCamera extends CameraComponent3D
   final double panSpeed = 2;
   final double orbitalSpeed = 0.5;
 
-  @override
-  FutureOr<void> onLoad() {
-    position = game.world.player.position + Vector3(0, 1, 2);
-    target.setFrom(game.world.player.position + Vector3(0, 1, 0));
-    return super.onLoad();
-  }
-
-  @override
-  bool onKeyEvent(RawKeyEvent event, Set<Key> keysPressed) {
-    super.onKeyEvent(event, keysPressed);
-    // Switch camera mode
-    if (isKeyDown(Key.digit1)) {
-      mode = CameraMode.free;
-      up = Vector3(0, 1, 0); // Reset roll
-    } else if (isKeyDown(Key.digit2)) {
-      mode = CameraMode.firstPerson;
-      up = Vector3(0, 1, 0); // Reset roll
-    } else if (isKeyDown(Key.digit3)) {
-      mode = CameraMode.thirdPerson;
-      up = Vector3(0, 1, 0); // Reset roll
-    } else if (isKeyDown(Key.digit4)) {
-      mode = CameraMode.orbital;
-      up = Vector3(0, 1, 0); // Reset roll
-    } else if (isKeyDown(Key.digit5)) {
-      mode = CameraMode.custom;
-      up = Vector3(0, 1, 0); // Reset roll
-    }
-
-    return true;
-  }
+  Player get player => game.world.player;
 
   @override
   void update(double dt) {
@@ -67,12 +32,8 @@ class KeyboardControlledCamera extends CameraComponent3D
       return;
     }
 
-    final mouseDelta = Mouse.getDelta();
-    if (mouseDelta.distance != 0) {
-      const mouseMoveSensitivity = 0.003;
-
-      yaw(-mouseDelta.dx * mouseMoveSensitivity, rotateAroundTarget: true);
-      pitch(-mouseDelta.dy * mouseMoveSensitivity, rotateAroundTarget: true);
-    }
+    final origin = player.position;
+    position.setFrom(origin);
+    target.setFrom(origin + player.forward);
   }
 }


### PR DESCRIPTION
I think I got a first person camera working, these are the features:

* stop rendering player ship, it was getting in the way of the view
* immediately rotate ship with mouse
* move and strafe ship with WASD
* camera always looks wherever the ship looks

It feels pretty good. the one weirdness I don't understand is if you comment the mouse movement and start to move forward with W, the camera tilts. it should not happen and I don't know why

I also had to remove the rendering of the player ship as it was interfering with the view. I think we can have a custom sprite obj just with the part of the ship we want to see and render that as part of the HUD instead